### PR TITLE
[PR #1] Enable communication profiling for the case of using network.

### DIFF
--- a/src/collectives/all_gather.cu
+++ b/src/collectives/all_gather.cu
@@ -4,29 +4,30 @@
  * See LICENSE.txt for license information
  ************************************************************************/
 
+#include "nccl.h"
 #include "core.h"
 #include "common_coll.h"
 #include "enqueue.h"
 #include "collectives.h"
 
 ncclResult_t ncclAllGatherFunc(const void* sendbuff, void* recvbuff, size_t count,
-    ncclDataType_t datatype, ncclRedOp_t op, int root, ncclComm_t comm, cudaStream_t stream) {
+    ncclDataType_t datatype, ncclRedOp_t op, int root, ncclComm_t comm, cudaStream_t stream, ncclProf_t* nccl_prof) {
   size_t nbytes = count*ncclTypeSize(datatype);
   INFO(COLL,"AllGather: opCount %lx sendbuff %p recvbuff %p count %zi datatype %d op %d root %d comm %p [nranks=%d] stream %p", comm->opCount, sendbuff, recvbuff, count, datatype, op, root, comm, comm->nRanks, stream);
   if (comm->nRanks == 1) {
     if (sendbuff != recvbuff)
       CUDACHECK(cudaMemcpyAsync(recvbuff, sendbuff, nbytes, cudaMemcpyDeviceToDevice, stream));
   } else {
-    NCCLCHECK(transportSaveProxies(ALLGATHER_SUBSTEPS, ALLGATHER_BUFCHUNKS, comm->nRanks-1, comm->nRanks, nbytes*comm->nRanks, proxyPatternRing, comm));
+    NCCLCHECK(transportSaveProxies(ALLGATHER_SUBSTEPS, ALLGATHER_BUFCHUNKS, comm->nRanks-1, comm->nRanks, nbytes*comm->nRanks, proxyPatternRing, comm, nccl_prof));
     NCCLCHECK(saveKernel(ncclCollAllGather, sendbuff, recvbuff, nbytes, ncclInt8, op, root, comm, stream, nbytes*comm->nRanks, 1));
   }
   return ncclSuccess;
 }
 
 NCCL_API(ncclResult_t, ncclAllGather, const void* sendbuff, void* recvbuff, size_t sendcount,
-    ncclDataType_t datatype, ncclComm_t comm, cudaStream_t stream);
+    ncclDataType_t datatype, ncclComm_t comm, cudaStream_t stream, ncclProf_t* nccl_prof);
 ncclResult_t ncclAllGather(const void* sendbuff, void* recvbuff, size_t sendcount,
-    ncclDataType_t datatype, ncclComm_t comm, cudaStream_t stream) {
+    ncclDataType_t datatype, ncclComm_t comm, cudaStream_t stream, ncclProf_t* nccl_prof) {
   return ncclEnqueueCheck(ncclAllGatherFunc, "AllGather", sendbuff, recvbuff, sendcount, datatype,
-          ncclSum, 0, comm, stream);
+          ncclSum, 0, comm, stream, nccl_prof);
 }

--- a/src/collectives/all_reduce.cu
+++ b/src/collectives/all_reduce.cu
@@ -4,29 +4,30 @@
  * See LICENSE.txt for license information
  ************************************************************************/
 
+#include "nccl.h"
 #include "core.h"
 #include "common_coll.h"
 #include "enqueue.h"
 #include "collectives.h"
 
 ncclResult_t ncclAllReduceFunc(const void* sendbuff, void* recvbuff, size_t count,
-    ncclDataType_t datatype, ncclRedOp_t op, int root, ncclComm_t comm, cudaStream_t stream) {
+    ncclDataType_t datatype, ncclRedOp_t op, int root, ncclComm_t comm, cudaStream_t stream, ncclProf_t* nccl_prof) {
   size_t nbytes = count*ncclTypeSize(datatype);
   INFO(COLL,"AllReduce: opCount %lx sendbuff %p recvbuff %p count %zi datatype %d op %d root %d comm %p [nranks=%d] stream %p", comm->opCount, sendbuff, recvbuff, count, datatype, op, root, comm, comm->nRanks, stream);
   if (comm->nRanks == 1) {
     if (sendbuff != recvbuff)
       CUDACHECK(cudaMemcpyAsync(recvbuff, sendbuff, nbytes, cudaMemcpyDeviceToDevice, stream));
   } else {
-    NCCLCHECK(transportSaveProxies(ALLREDUCE_SUBSTEPS, ALLREDUCE_BUFCHUNKS, (comm->nRanks)*2-2, comm->nRanks, nbytes, proxyPatternRing, comm));
+    NCCLCHECK(transportSaveProxies(ALLREDUCE_SUBSTEPS, ALLREDUCE_BUFCHUNKS, (comm->nRanks)*2-2, comm->nRanks, nbytes, proxyPatternRing, comm, nccl_prof));
     NCCLCHECK(saveKernel(ncclCollAllReduce, sendbuff, recvbuff, count, datatype, op, root, comm, stream, nbytes, comm->nRanks));
   }
   return ncclSuccess;
 }
 
 NCCL_API(ncclResult_t, ncclAllReduce, const void* sendbuff, void* recvbuff, size_t count,
-    ncclDataType_t datatype, ncclRedOp_t op, ncclComm_t comm, cudaStream_t stream);
+    ncclDataType_t datatype, ncclRedOp_t op, ncclComm_t comm, cudaStream_t stream, ncclProf_t* nccl_prof);
 ncclResult_t ncclAllReduce(const void* sendbuff, void* recvbuff, size_t count,
-    ncclDataType_t datatype, ncclRedOp_t op, ncclComm_t comm, cudaStream_t stream) {
+    ncclDataType_t datatype, ncclRedOp_t op, ncclComm_t comm, cudaStream_t stream, ncclProf_t* nccl_prof) {
   return ncclEnqueueCheck(ncclAllReduceFunc, "AllReduce", sendbuff, recvbuff, count, datatype,
-          op, 0, comm, stream);
+          op, 0, comm, stream, nccl_prof);
 }

--- a/src/collectives/reduce.cu
+++ b/src/collectives/reduce.cu
@@ -4,20 +4,21 @@
  * See LICENSE.txt for license information
  ************************************************************************/
 
+#include "nccl.h"
 #include "core.h"
 #include "common_coll.h"
 #include "enqueue.h"
 #include "collectives.h"
 
 ncclResult_t ncclReduceFunc(const void* sendbuff, void* recvbuff, const size_t count,
-    ncclDataType_t datatype, ncclRedOp_t op, int root, ncclComm_t comm, cudaStream_t stream) {
+    ncclDataType_t datatype, ncclRedOp_t op, int root, ncclComm_t comm, cudaStream_t stream, ncclProf_t* nccl_prof) {
   size_t nbytes = count*ncclTypeSize(datatype);
   INFO(COLL,"Reduce: opCount %lx sendbuff %p recvbuff %p count %zi datatype %d op %d root %d comm %p [nranks=%d] stream %p", comm->opCount, sendbuff, recvbuff, count, datatype, op, root, comm, comm->nRanks, stream);
   if (comm->nRanks == 1) {
     if (sendbuff != recvbuff)
       CUDACHECK(cudaMemcpyAsync(recvbuff, sendbuff, nbytes, cudaMemcpyDeviceToDevice, stream));
   } else {
-    NCCLCHECK(transportSaveProxies(REDUCE_SUBSTEPS, REDUCE_BUFCHUNKS, 1, 1, nbytes, proxyPatternTo(root), comm));
+    NCCLCHECK(transportSaveProxies(REDUCE_SUBSTEPS, REDUCE_BUFCHUNKS, 1, 1, nbytes, proxyPatternTo(root), comm, nccl_prof));
     NCCLCHECK(saveKernel(ncclCollReduce, sendbuff, recvbuff, count, datatype, op, root, comm, stream, nbytes, 1));
   }
 
@@ -25,9 +26,9 @@ ncclResult_t ncclReduceFunc(const void* sendbuff, void* recvbuff, const size_t c
 }
 
 NCCL_API(ncclResult_t, ncclReduce, const void* sendbuff, void* recvbuff, size_t count,
-    ncclDataType_t datatype, ncclRedOp_t op, int root, ncclComm_t comm, cudaStream_t stream);
+    ncclDataType_t datatype, ncclRedOp_t op, int root, ncclComm_t comm, cudaStream_t stream, ncclProf_t* nccl_prof);
 ncclResult_t ncclReduce(const void* sendbuff, void* recvbuff, size_t count,
-    ncclDataType_t datatype, ncclRedOp_t op, int root, ncclComm_t comm, cudaStream_t stream) {
+    ncclDataType_t datatype, ncclRedOp_t op, int root, ncclComm_t comm, cudaStream_t stream, ncclProf_t* nccl_prof) {
   return ncclEnqueueCheck(ncclReduceFunc, "Reduce", sendbuff, recvbuff, count, datatype,
-          op, root, comm, stream);
+          op, root, comm, stream, nccl_prof);
 }

--- a/src/collectives/reduce_scatter.cu
+++ b/src/collectives/reduce_scatter.cu
@@ -4,29 +4,30 @@
  * See LICENSE.txt for license information
  ************************************************************************/
 
+#include "nccl.h"
 #include "core.h"
 #include "common_coll.h"
 #include "enqueue.h"
 #include "collectives.h"
 
 ncclResult_t ncclReduceScatterFunc(const void* sendbuff, void* recvbuff, size_t count,
-    ncclDataType_t datatype, ncclRedOp_t op, int root, ncclComm_t comm, cudaStream_t stream) {
+    ncclDataType_t datatype, ncclRedOp_t op, int root, ncclComm_t comm, cudaStream_t stream, ncclProf_t* nccl_prof) {
   size_t nbytes = count*ncclTypeSize(datatype);
   INFO(COLL,"ReduceScatter: opCount %lx sendbuff %p recvbuff %p count %zi datatype %d op %d root %d comm %p [nranks=%d] stream %p", comm->opCount, sendbuff, recvbuff, count, datatype, op, root, comm, comm->nRanks, stream);
   if (comm->nRanks == 1) {
     if (sendbuff != recvbuff)
       CUDACHECK(cudaMemcpyAsync(recvbuff, sendbuff, nbytes, cudaMemcpyDeviceToDevice, stream));
   } else {
-    NCCLCHECK(transportSaveProxies(REDUCESCATTER_SUBSTEPS, REDUCESCATTER_BUFCHUNKS, comm->nRanks-1, comm->nRanks, nbytes*comm->nRanks, proxyPatternRing, comm));
+    NCCLCHECK(transportSaveProxies(REDUCESCATTER_SUBSTEPS, REDUCESCATTER_BUFCHUNKS, comm->nRanks-1, comm->nRanks, nbytes*comm->nRanks, proxyPatternRing, comm, nccl_prof));
     NCCLCHECK(saveKernel(ncclCollReduceScatter, sendbuff, recvbuff, count, datatype, op, root, comm, stream, nbytes*comm->nRanks, 1));
   }
   return ncclSuccess;
 }
 
 NCCL_API(ncclResult_t, ncclReduceScatter, const void* sendbuff, void* recvbuff, size_t recvcount,
-    ncclDataType_t datatype, ncclRedOp_t op, ncclComm* comm, cudaStream_t stream);
+    ncclDataType_t datatype, ncclRedOp_t op, ncclComm* comm, cudaStream_t stream, ncclProf_t* nccl_prof);
 ncclResult_t ncclReduceScatter(const void* sendbuff, void* recvbuff, size_t recvcount,
-    ncclDataType_t datatype, ncclRedOp_t op, ncclComm* comm, cudaStream_t stream) {
+    ncclDataType_t datatype, ncclRedOp_t op, ncclComm* comm, cudaStream_t stream, ncclProf_t* nccl_prof) {
   return ncclEnqueueCheck(ncclReduceScatterFunc, "ReduceScatter", sendbuff, recvbuff, recvcount, datatype,
-          op, 0, comm, stream);
+          op, 0, comm, stream, nccl_prof);
 }

--- a/src/include/enqueue.h
+++ b/src/include/enqueue.h
@@ -7,15 +7,16 @@
 #ifndef NCCL_ENQUEUE_H_
 #define NCCL_ENQUEUE_H_
 
+#include "nccl.h"
 #include "core.h"
 #include "group.h"
 
 typedef ncclResult_t(*ncclFunc_t)(const void* sendbuff, void* recvbuff, size_t count,
-    ncclDataType_t type, ncclRedOp_t op, int root, ncclComm_t comm, cudaStream_t stream);
+    ncclDataType_t type, ncclRedOp_t op, int root, ncclComm_t comm, cudaStream_t stream, ncclProf_t* nccl_prof);
 
 ncclResult_t ncclEnqueueCheck(ncclFunc_t func, const char* primName, const void* sendbuff,
     void* recvbuff, size_t count, ncclDataType_t type, ncclRedOp_t op, int root,
-    ncclComm_t comm, cudaStream_t stream);
+    ncclComm_t comm, cudaStream_t stream, ncclProf_t* nccl_prof);
 ncclResult_t ncclCpuBarrierIn(ncclComm_t comm, int* isLast);
 ncclResult_t ncclCpuBarrierLast(ncclComm_t comm);
 ncclResult_t ncclCpuBarrierOut(ncclComm_t comm);

--- a/src/include/group.h
+++ b/src/include/group.h
@@ -18,7 +18,7 @@ typedef ncclResult_t(*ncclInitFunc_t)(ncclComm_t* newcomm, int ndev, ncclUniqueI
 ncclResult_t ncclAsyncInit(ncclInitFunc_t func, int cudaDev, ncclComm_t* newcomm, int ndev, ncclUniqueId commId, int myrank);
 
 typedef ncclResult_t(*ncclCollFunc_t)(const void* sendbuff, void* recvbuff, size_t count,
-    ncclDataType_t type, ncclRedOp_t op, int root, ncclComm_t comm, cudaStream_t stream);
+    ncclDataType_t type, ncclRedOp_t op, int root, ncclComm_t comm, cudaStream_t stream, ncclProf_t* nccl_prof);
 
 ncclResult_t ncclAsyncColl(ncclComm_t comm);
 #endif

--- a/src/include/stat_collector.h
+++ b/src/include/stat_collector.h
@@ -1,0 +1,188 @@
+/*************************************************************************
+ * Copyright (c) 2019, SPLab. All rights reserved.
+ ************************************************************************/
+
+#ifndef STAT_COLLECTOR_H_
+#define STAT_COLLECTOR_H_
+
+#include "nccl.h"
+#include <stdlib.h>
+#include <string>
+#include <unordered_map>
+#include <vector>
+#include <utility>
+#include <unistd.h>
+#include <iostream>
+#include <assert.h>
+
+inline const std::string CommTypeToString(commType_t comm_type) {
+  switch (comm_type) {
+    case P2P_SEND:  return std::string("P2P_SEND");
+    case P2P_RECV:  return std::string("P2P_RECV");
+    case SHM_SEND:  return std::string("SHM_SEND");
+    case SHM_RECV:  return std::string("SHM_RECV");
+    case NET_SEND:  return std::string("NET_SEND");
+    case NET_RECV:  return std::string("NET_RECV");
+    default:        return std::string("UndefinedType");
+  }
+}
+
+inline commStat_t* create_comm_stat(commType_t comm_type, uint64_t start_micros, uint64_t end_micros, int comm_bytes) {
+  commStat_t* comm_stat = (commStat_t*) malloc(sizeof(commStat_t));
+  comm_stat->comm_type = comm_type;
+  comm_stat->start_micros = start_micros;
+  comm_stat->end_micros = end_micros;
+  comm_stat->comm_bytes = comm_bytes;
+  return comm_stat;
+}
+
+inline void enqueue_stat(ncclProf_t* nccl_prof, commStat_t* comm_stat) {
+  pthread_mutex_lock(&nccl_prof->mu_);
+  if (nccl_prof->stat_vector == nullptr) {
+    nccl_prof->stat_vector = new std::vector<commStat_t*>();
+  }
+  nccl_prof->stat_vector->push_back(comm_stat);
+  pthread_mutex_unlock(&nccl_prof->mu_);
+}
+
+inline const std::string ncclprof_tostring(ncclProf_t* nccl_prof) {
+  std::string ret = "";
+  std::string tensor_name(nccl_prof->tensor_name);
+  ret += std::string("{\n  \"Step\": ") + std::to_string(nccl_prof->step) + std::string(",\n  \"Tensor\": ") + tensor_name + std::string(",\n  \"Worker_ID\": ") + std::to_string(nccl_prof->worker_id);
+  ret += std::string(",\n  CommStat List: {\n");
+  std::vector<commStat_t*>::iterator iter;
+  for (iter = nccl_prof->stat_vector->begin(); iter != nccl_prof->stat_vector->end(); iter++) {
+    if (iter != nccl_prof->stat_vector->begin()) {
+      ret += std::string(",\n");
+    }
+    ret += std::string("    { CommType: ") + CommTypeToString((*iter)->comm_type);
+    ret += std::string(", StartMicros: ") + std::to_string((*iter)->start_micros);
+    ret += std::string(", EndMicros: ") + std::to_string((*iter)->end_micros);
+    ret += std::string(", CommBytes: ") + std::to_string((*iter)->comm_bytes) + std::string(" }");
+  }
+  ret += std::string("\n  }\n");
+  ret += std::string("}\n");
+  return ret;
+}
+
+/* Class for CommStat Collector */
+class StatCollector {
+public:
+  StatCollector() : worker_id(-1), mu_(PTHREAD_MUTEX_INITIALIZER), \
+                    saved_in_file(0), started_save_in_file_thread(0) {
+  }
+
+  ~StatCollector() {
+    std::unordered_map<int64_t, NcclProfVector*>::iterator iter;
+    for (iter = step_stats_.begin(); iter != step_stats_.end(); iter++) {
+      NcclProfVector::iterator iter_;
+      for (iter_ = iter->second->begin(); iter_ != iter->second->end(); iter_++) {
+        std::vector<commStat_t*>::iterator iter__;
+        for (iter__ = (*iter_)->stat_vector->begin(); iter__ != (*iter_)->stat_vector->end(); iter__++) {
+          free(*iter__);
+        }
+        (*iter_)->stat_vector->clear();
+        free((char*)(*iter_)->tensor_name);
+      }
+      iter->second->clear();
+    }
+    step_stats_.clear();
+  }
+
+  void save(ncclProf_t* nccl_prof) {
+    pthread_mutex_lock(&mu_);
+    if (!nccl_prof->saved) {
+      std::unordered_map<int64_t, NcclProfVector*>::iterator iter = step_stats_.find(nccl_prof->step);
+      if (iter == step_stats_.end()) {
+        NcclProfVector* nccl_prof_vector = new NcclProfVector();
+        step_stats_.insert(std::pair<int64_t, NcclProfVector*>(nccl_prof->step, nccl_prof_vector));
+      }
+      step_stats_[nccl_prof->step]->push_back(nccl_prof);
+      nccl_prof->saved = 1;
+    }
+    if (worker_id == -1) {
+      worker_id = nccl_prof->worker_id;
+    } else {
+      assert(worker_id == nccl_prof->worker_id);
+    }
+    pthread_mutex_unlock(&mu_);
+  }
+
+  ncclResult_t save_metadata() {
+    FILE *fp;
+    std::string homedir(std::getenv("HOME"));
+    char _hostname[HOST_NAME_MAX];
+    gethostname(_hostname, HOST_NAME_MAX);
+    std::string hostname(_hostname);
+    std::string save_filedir = std::string(std::getenv("HOME")) + std::string("/prof_dir/") + hostname + \
+                               std::string("/worker:") + std::to_string(worker_id);
+    system(("mkdir -p " + save_filedir).c_str());
+    std::unordered_map<int64_t, NcclProfVector*>::iterator iter;
+    for (iter = step_stats_.begin(); iter != step_stats_.end(); iter++) {
+      std::string save_filename = save_filedir + std::string("/nccl_meta_") + std::to_string(iter->first);
+      if ((fp = fopen(save_filename.c_str(), "w")) == NULL) {
+        std::cout << "Cannot open file " << save_filename << std::endl;
+        return ncclSystemError;
+      }
+      NcclProfVector::iterator iter_;
+      for (iter_ = iter->second->begin(); iter_ != iter->second->end(); iter_++) {
+        const std::string ncclprof_str = ncclprof_tostring(*iter_);
+        fputs(ncclprof_str.c_str(), fp);
+      }
+      fclose(fp);
+    }
+    return ncclSuccess;
+  }
+
+  void save_in_file() {
+    pthread_mutex_lock(&mu_);
+    if (started_save_in_file_thread) {
+      pthread_mutex_unlock(&mu_);
+      return;
+    }
+    started_save_in_file_thread = 1;
+    pthread_mutex_unlock(&mu_);
+    while(!saved_in_file) {
+      sleep(1);
+    }
+    save_metadata();
+  }
+
+  void set_saved_in_file() {
+    pthread_mutex_lock(&mu_);
+    saved_in_file = 1;
+    pthread_mutex_unlock(&mu_);
+  }
+
+private:
+  typedef std::vector<ncclProf_t*> NcclProfVector;
+  pthread_mutex_t mu_;
+  std::unordered_map<int64_t, NcclProfVector*> step_stats_;
+  int worker_id;
+  int started_save_in_file_thread;
+  int saved_in_file; // Whether all the profiled data is saved in file.
+                     // Assume no more data is profiled after saved_in_file became 1.
+};
+
+static pthread_mutex_t scmu_ = PTHREAD_MUTEX_INITIALIZER;
+inline StatCollector* GetStatCollector() {
+  pthread_mutex_lock(&scmu_);
+  static StatCollector* stat_collector = new StatCollector();
+  pthread_mutex_unlock(&scmu_);
+  return stat_collector;
+}
+
+inline void* StatCollectorSaveInFileThread(void *unused) {
+  StatCollector* stat_collector = GetStatCollector();
+  stat_collector->save_in_file();
+  static const int ok_return = 1;
+  return (void*) &ok_return;
+}
+
+inline ncclResult_t StartStatCollector() {
+  pthread_t thread_id;
+  pthread_create(&thread_id, NULL, StatCollectorSaveInFileThread, NULL);
+  return ncclSuccess;
+}
+
+#endif // end include guard

--- a/src/include/transport.h
+++ b/src/include/transport.h
@@ -42,6 +42,7 @@ struct ncclProxyArgs {
   int llMode;
   bool needProxy;
   int active;   // add component before this line -- it is left out during initialization
+  ncclProf_t* nccl_prof;
 };
 
 struct ncclTransportComm {
@@ -93,7 +94,7 @@ static inline int proxyPatternTo(int root) { return -1-root; }
 static inline enum proxyMode proxyPatternMode(int pattern) { return (pattern == 0) ? proxyRing : ((pattern > 0) ? proxyFrom : proxyTo); }
 static inline int proxyPatternRoot(int pattern) { return (pattern > 0) ? pattern-1 : -pattern-1; }
 
-ncclResult_t transportSaveProxies(int substeps, int subchunks, int nstepsPerRound, int nblocksPerRound, size_t size, int pattern, struct ncclComm* comm);
+ncclResult_t transportSaveProxies(int substeps, int subchunks, int nstepsPerRound, int nblocksPerRound, size_t size, int pattern, struct ncclComm* comm, ncclProf_t* nccl_prof);
 ncclResult_t transportStartProxies(struct ncclComm* comm);
 
 #include <unistd.h>

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -9,6 +9,7 @@
 
 #include "nccl.h"
 #include <stdint.h>
+#include <chrono>
 
 ncclResult_t getHostName(char* hostname, int maxlen);
 uint64_t getHostHash();
@@ -21,5 +22,7 @@ struct netIf {
 
 int parseStringList(const char* string, struct netIf* ifList, int maxList);
 bool matchIfList(const char* string, int port, struct netIf* ifList, int listSize);
+
+uint64_t now_micros();
 
 #endif

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -9,7 +9,6 @@
 
 #include "nccl.h"
 #include <stdint.h>
-#include <chrono>
 
 ncclResult_t getHostName(char* hostname, int maxlen);
 uint64_t getHostHash();

--- a/src/init.cu
+++ b/src/init.cu
@@ -858,4 +858,3 @@ ncclResult_t ncclCommUserRank(const ncclComm_t comm, int* rank) {
   *rank = comm->rank;
   return ncclSuccess;
 }
-

--- a/src/init.cu
+++ b/src/init.cu
@@ -4,8 +4,8 @@
  * See LICENSE.txt for license information
  ************************************************************************/
 
-#include "nccl.h"
 #include "core.h"
+#include "stat_collector.h"
 #include "ring.h"
 #include "param.h"
 #include "nvmlwrap.h"
@@ -626,6 +626,8 @@ ncclResult_t ncclCommInitRank(ncclComm_t* newcomm, int nranks, ncclUniqueId comm
     return ncclInvalidArgument;
   }
 
+  NCCLCHECK(StartStatCollector());
+
   if (ncclAsyncMode()) {
     int cudaDev;
     CUDACHECK(cudaGetDevice(&cudaDev));
@@ -856,3 +858,4 @@ ncclResult_t ncclCommUserRank(const ncclComm_t comm, int* rank) {
   *rank = comm->rank;
   return ncclSuccess;
 }
+

--- a/src/misc/utils.cu
+++ b/src/misc/utils.cu
@@ -127,3 +127,9 @@ bool matchIfList(const char* string, int port, struct netIf* ifList, int listSiz
   }
   return false;
 }
+
+uint64_t now_micros() {
+  return std::chrono::duration_cast<std::chrono::microseconds>(
+                   std::chrono::system_clock::now().time_since_epoch())
+    .count();
+}

--- a/src/nccl.h.in
+++ b/src/nccl.h.in
@@ -7,6 +7,10 @@
 #ifndef NCCL_H_
 #define NCCL_H_
 
+#include <stdlib.h>
+#include <memory>
+#include <mutex>
+#include <vector>
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
 
@@ -24,6 +28,31 @@ extern "C" {
 
 /* Opaque handle to communicator */
 typedef struct ncclComm* ncclComm_t;
+
+/* Profiling support for DL Frameworks (supports only TF now) */
+typedef enum { P2P_SEND = 0,
+               P2P_RECV = 1,
+               SHM_SEND = 2,
+               SHM_RECV = 3,
+               NET_SEND = 4,
+               NET_RECV = 5 } commType_t;
+
+typedef struct commStat {
+  commType_t comm_type;
+  uint64_t start_micros;
+  uint64_t end_micros;
+  int comm_bytes;
+} commStat_t;
+
+typedef struct ncclProf {
+  int do_profile;
+  int64_t step;
+  int worker_id;
+  const char* tensor_name;
+  pthread_mutex_t mu_;
+  std::vector<commStat_t*>* stat_vector;
+  int saved; // Flag indicates whether it is saved in StatCollector
+} ncclProf_t;
 
 #define NCCL_UNIQUE_ID_BYTES 128
 typedef struct { char internal[NCCL_UNIQUE_ID_BYTES]; } ncclUniqueId;
@@ -132,9 +161,9 @@ typedef enum { ncclInt8       = 0, ncclChar       = 0,
  * In-place operation will happen if sendbuff == recvbuff.
  */
 ncclResult_t  ncclReduce(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype,
-    ncclRedOp_t op, int root, ncclComm_t comm, cudaStream_t stream);
+    ncclRedOp_t op, int root, ncclComm_t comm, cudaStream_t stream, ncclProf_t* nccl_prof);
 ncclResult_t pncclReduce(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype,
-    ncclRedOp_t op, int root, ncclComm_t comm, cudaStream_t stream);
+    ncclRedOp_t op, int root, ncclComm_t comm, cudaStream_t stream, ncclProf_t* nccl_prof);
 
 /*
  * (deprecated) Broadcast (in-place)
@@ -146,9 +175,9 @@ ncclResult_t pncclReduce(const void* sendbuff, void* recvbuff, size_t count, ncc
  * This operation is implicitely in place.
  */
 ncclResult_t  ncclBcast(void* buff, size_t count, ncclDataType_t datatype, int root,
-    ncclComm_t comm, cudaStream_t stream);
+    ncclComm_t comm, cudaStream_t stream, ncclProf_t* nccl_prof);
 ncclResult_t pncclBcast(void* buff, size_t count, ncclDataType_t datatype, int root,
-    ncclComm_t comm, cudaStream_t stream);
+    ncclComm_t comm, cudaStream_t stream, ncclProf_t* nccl_prof);
 
 /*
  * Broadcast
@@ -160,9 +189,9 @@ ncclResult_t pncclBcast(void* buff, size_t count, ncclDataType_t datatype, int r
  * In-place operation will happen if sendbuff == recvbuff.
  */
 ncclResult_t  ncclBroadcast(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype, int root,
-    ncclComm_t comm, cudaStream_t stream);
+    ncclComm_t comm, cudaStream_t stream, ncclProf_t* nccl_prof);
 ncclResult_t pncclBroadcast(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype, int root,
-    ncclComm_t comm, cudaStream_t stream);
+    ncclComm_t comm, cudaStream_t stream, ncclProf_t* nccl_prof);
 
 /*
  * All-Reduce
@@ -173,9 +202,9 @@ ncclResult_t pncclBroadcast(const void* sendbuff, void* recvbuff, size_t count, 
  * In-place operation will happen if sendbuff == recvbuff.
  */
 ncclResult_t  ncclAllReduce(const void* sendbuff, void* recvbuff, size_t count,
-    ncclDataType_t datatype, ncclRedOp_t op, ncclComm_t comm, cudaStream_t stream);
+    ncclDataType_t datatype, ncclRedOp_t op, ncclComm_t comm, cudaStream_t stream, ncclProf_t* nccl_prof);
 ncclResult_t pncclAllReduce(const void* sendbuff, void* recvbuff, size_t count,
-    ncclDataType_t datatype, ncclRedOp_t op, ncclComm_t comm, cudaStream_t stream);
+    ncclDataType_t datatype, ncclRedOp_t op, ncclComm_t comm, cudaStream_t stream, ncclProf_t* nccl_prof);
 
 /*
  * Reduce-Scatter
@@ -190,10 +219,10 @@ ncclResult_t pncclAllReduce(const void* sendbuff, void* recvbuff, size_t count,
  */
 ncclResult_t  ncclReduceScatter(const void* sendbuff, void* recvbuff,
     size_t recvcount, ncclDataType_t datatype, ncclRedOp_t op, ncclComm_t comm,
-    cudaStream_t stream);
+    cudaStream_t stream, ncclProf_t* nccl_prof);
 ncclResult_t pncclReduceScatter(const void* sendbuff, void* recvbuff,
     size_t recvcount, ncclDataType_t datatype, ncclRedOp_t op, ncclComm_t comm,
-    cudaStream_t stream);
+    cudaStream_t stream, ncclProf_t* nccl_prof);
 
 /*
  * All-Gather
@@ -206,9 +235,9 @@ ncclResult_t pncclReduceScatter(const void* sendbuff, void* recvbuff,
  * In-place operations will happen if sendbuff == recvbuff + rank * sendcount.
  */
 ncclResult_t  ncclAllGather(const void* sendbuff, void* recvbuff, size_t sendcount,
-    ncclDataType_t datatype, ncclComm_t comm, cudaStream_t stream);
+    ncclDataType_t datatype, ncclComm_t comm, cudaStream_t stream, ncclProf_t* nccl_prof);
 ncclResult_t pncclAllGather(const void* sendbuff, void* recvbuff, size_t sendcount,
-    ncclDataType_t datatype, ncclComm_t comm, cudaStream_t stream);
+    ncclDataType_t datatype, ncclComm_t comm, cudaStream_t stream, ncclProf_t* nccl_prof);
 
 /*
  * Group semantics

--- a/src/transport/net.cu
+++ b/src/transport/net.cu
@@ -14,7 +14,6 @@
 #include "utils.h"
 #include <cuda_runtime.h>
 #include <assert.h>
-#include <iostream>
 
 #define NET_MAX_IFS 16
 


### PR DESCRIPTION
**Major changes:**
This PR enables NCCL communication profiling.
The following is the summary of this PR.
1. src/collectives/*.cu (all_gather, all_reduce ...)
NCCL APIs are changed to receive `nccl_prof` parameter as a function parameter. Then, they propagate the parameter to `transportSaveProxies`, which saves data to be transfered later using network (refer `src/transport.cu`).

2. src/init.cu
Call `StartStatCollector` in `ncclCommInitRank` to start nccl profiling while initializing nccl communication.

3. src/transport/net.cu
`netSendProxy` and `netRecvProxy` are the functions that actually send and receive data by calling `ncclNetIsend` and `ncclNetIrecv`. ** ~For now, this PR saves log for asynchronous call of sending and receiving data. It will be fixed soon.~ In addition, this PR saves NCCL profiling data from step 0 to 30, which MUST be changed later (this part is marked as _// TODO(HJ): For now, we set saved nccl profiling data manually_).**

4. src/nccl.h.in
Some structures `comm_stat` and `nccl_prof` are newly defined.

5. src/include/stat_collector.h
`StatCollector` saves all the profiled data into `step_stats_` map (key is a step and value is a vector of profiled data).
Explanation of some main functions.
`StartStatCollector`: Starts new thread that checks whether it is the time to save profiled data or not. If it is the time, save profiled data into the file.
`GetStatCollector`: Returns _static_ stat_collector. There is only one stat_collector per worker.


**Minor changes to note:**
None

**Tests for the changes:**
To build and use this NCCL code, use the following command.
```shell
cd nccl/
make -j src.build
sudo cp ./src/nccl.h /usr/local/cuda/include/
sudo cp ./build/lib/* /usr/lib/x86_64-linux-gnu/
```

**Other comments:**
To enable this PR, use `EnableNcclProfiling` branch of Horovod and `fix_nccl_api` branch of Parallax.
This PR merges `EnableProfile` branch into `v2.3.7-1-EnableProfile`. Use `v2.3.7-1-EnableProfile` to use this PR.